### PR TITLE
Decouple the node selection and expansion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,7 @@ build/Release
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
 
+# IDE metadata
+.idea
+
 lib/

--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ class TreeExample extends React.Component {
     constructor(props){
         super(props);
         this.state = {};
-        this.onToggle = this.onToggle.bind(this);
+        this.onSelect = this.onSelect.bind(this);
     }
-    onToggle(node, toggled){
+    onSelect(node, toggled){
         if(this.state.cursor){this.state.cursor.active = false;}
         node.active = true;
         if(node.children){ node.toggled = toggled; }
@@ -69,7 +69,7 @@ class TreeExample extends React.Component {
         return (
             <Treebeard
                 data={data}
-                onToggle={this.onToggle}
+                onSelect={this.onSelect}
             />
         );
     }
@@ -86,7 +86,7 @@ ReactDOM.render(<TreeExample/>, content);
 
 Data that drives the tree view. State-driven effects can be built by manipulating the attributes in this object. Also supports an array for multiple nodes at the root level. An example can be found in `example/data.js`
 
-#### onToggle
+#### onSelect
 `PropTypes.func`
 
 Callback function when a node is toggled / clicked. Passes 2 attributes: the data node and it's toggled boolean state.

--- a/example/app.js
+++ b/example/app.js
@@ -50,10 +50,10 @@ class DemoTree extends React.Component {
         super();
 
         this.state = {data};
-        this.onToggle = this.onToggle.bind(this);
+        this.onSelect = this.onSelect.bind(this);
     }
 
-    onToggle(node, toggled) {
+    onSelect(node, toggled) {
         const {cursor} = this.state;
 
         if (cursor) {
@@ -97,7 +97,7 @@ class DemoTree extends React.Component {
                 <div style={styles.component}>
                     <Treebeard data={stateData}
                                decorators={decorators}
-                               onToggle={this.onToggle}/>
+                               onSelect={this.onSelect} />
                 </div>
                 <div style={styles.component}>
                     <NodeViewer node={cursor}/>

--- a/example/app.js
+++ b/example/app.js
@@ -13,14 +13,14 @@ import * as filters from './filter';
 const HELP_MSG = 'Select A Node To See Its Data Structure Here...';
 
 // Example: Customising The Header Decorator To Include Icons
-decorators.Header = ({style, node}) => {
+decorators.Header = ({style, node, onClick}) => {
     const iconType = node.children ? 'folder' : 'file-text';
     const iconClass = `fa fa-${iconType}`;
     const iconStyle = {marginRight: '5px'};
 
     return (
         <div style={style.base}>
-            <div style={style.title}>
+            <div style={style.title} onClick={onClick}>
                 <i className={iconClass} style={iconStyle}/>
 
                 {node.name}
@@ -53,7 +53,7 @@ class DemoTree extends React.Component {
         this.onSelect = this.onSelect.bind(this);
     }
 
-    onSelect(node, toggled) {
+    onSelect(node) {
         const {cursor} = this.state;
 
         if (cursor) {
@@ -61,11 +61,12 @@ class DemoTree extends React.Component {
         }
 
         node.active = true;
-        if (node.children) {
-            node.toggled = toggled;
-        }
 
         this.setState({cursor: node});
+    }
+
+    onOpen(node) {
+        console.log('open', node);
     }
 
     onFilterMouseUp(e) {
@@ -97,7 +98,8 @@ class DemoTree extends React.Component {
                 <div style={styles.component}>
                     <Treebeard data={stateData}
                                decorators={decorators}
-                               onSelect={this.onSelect} />
+                               onSelect={this.onSelect}
+                               onOpen={this.onOpen} />
                 </div>
                 <div style={styles.component}>
                     <NodeViewer node={cursor}/>

--- a/src/components/decorators.js
+++ b/src/components/decorators.js
@@ -12,13 +12,13 @@ Loading.propTypes = {
     style: PropTypes.object
 };
 
-const Toggle = ({style}) => {
+const Toggle = ({style, onOpen}) => {
     const {height, width} = style;
     const midHeight = height * 0.5;
     const points = `0,0 0,${height} ${width},${midHeight}`;
 
     return (
-        <div style={style.base}>
+        <div style={style.base} onClick={onOpen}>
             <div style={style.wrapper}>
                 <svg height={height} width={width}>
                     <polygon points={points}
@@ -29,12 +29,13 @@ const Toggle = ({style}) => {
     );
 };
 Toggle.propTypes = {
-    style: PropTypes.object
+    style: PropTypes.object,
+    onOpen: PropTypes.func
 };
 
-const Header = ({node, style}) => {
+const Header = ({node, style, onClick}) => {
     return (
-        <div style={style.base}>
+        <div style={style.base} onClick={onClick}>
             <div style={style.title}>
                 {node.name}
             </div>
@@ -43,6 +44,7 @@ const Header = ({node, style}) => {
 };
 Header.propTypes = {
     style: PropTypes.object,
+    onClient: PropTypes.func,
     node: PropTypes.object.isRequired
 };
 
@@ -52,12 +54,13 @@ class Container extends React.Component {
         const {style, decorators, terminal, onClick, node} = this.props;
 
         return (
-            <div onClick={onClick}
-                 ref={ref => this.clickableRef = ref}
+            <div ref={ref => this.clickableRef = ref}
                  style={style.container}>
                 {!terminal ? this.renderToggle() : null}
 
-                <decorators.Header node={node}
+                <decorators.Header onClick={onClick}
+                                   ref={ref => this.clickableRef = ref}
+                                   node={node}
                                    style={style.header}/>
             </div>
         );
@@ -80,16 +83,17 @@ class Container extends React.Component {
     }
 
     renderToggleDecorator() {
-        const {style, decorators} = this.props;
+        const {style, decorators, onOpen} = this.props;
 
-        return <decorators.Toggle style={style.toggle}/>;
+        return <decorators.Toggle onOpen={onOpen} style={style.toggle}/>;
     }
 }
 Container.propTypes = {
     style: PropTypes.object.isRequired,
     decorators: PropTypes.object.isRequired,
     terminal: PropTypes.bool.isRequired,
-    onClick: PropTypes.func.isRequired,
+    onClick: PropTypes.func,
+    onOpen: PropTypes.func,
     animations: PropTypes.oneOfType([
         PropTypes.object,
         PropTypes.bool

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -26,7 +26,7 @@ class NodeHeader extends React.Component {
     }
 
     render() {
-        const {animations, decorators, node, onClick, style} = this.props;
+        const {animations, decorators, node, onClick, onOpen, style} = this.props;
         const {active, children} = node;
         const terminal = !children;
         const container = [style.link, active ? style.activeLink : null];
@@ -37,8 +37,9 @@ class NodeHeader extends React.Component {
                                   decorators={decorators}
                                   node={node}
                                   onClick={onClick}
+                                  onOpen={onOpen}
                                   style={headerStyles}
-                                  terminal={terminal}/>
+                                  terminal={terminal} />
         );
     }
 }
@@ -51,7 +52,8 @@ NodeHeader.propTypes = {
         PropTypes.bool
     ]).isRequired,
     node: PropTypes.object.isRequired,
-    onClick: PropTypes.func
+    onClick: PropTypes.func,
+    onOpen: PropTypes.func
 };
 
 export default NodeHeader;

--- a/src/components/node.js
+++ b/src/components/node.js
@@ -11,6 +11,22 @@ class TreeNode extends React.Component {
         super();
 
         this.onClick = this.onClick.bind(this);
+        this.onOpen = this.onOpen.bind(this);
+    }
+
+    onOpen() {
+        console.log('treenode', 'onopen');
+        const {node, onOpen} = this.props;
+
+        if (node.children) {
+            node.toggled = !node.toggled;
+        }
+
+        if (onOpen) {
+            onOpen(node);
+        }
+
+        this.setState({node: node});
     }
 
     onClick() {
@@ -68,7 +84,7 @@ class TreeNode extends React.Component {
             return this.renderChildren(decorators, animations);
         }
 
-        const {animation, duration, ...restAnimationInfo} = animations.drawer;
+        const {...restAnimationInfo} = animations.drawer;
         return (
             <VelocityTransitionGroup {...restAnimationInfo}
                                      ref={ref => this.velocityRef = ref}>
@@ -85,6 +101,7 @@ class TreeNode extends React.Component {
                         decorators={decorators}
                         node={Object.assign({}, node)}
                         onClick={this.onClick}
+                        onOpen={this.onOpen}
                         style={style}/>
         );
     }
@@ -128,10 +145,11 @@ class TreeNode extends React.Component {
     }
 
     _eventBubbles() {
-        const {onSelect} = this.props;
+        const {onSelect, onOpen} = this.props;
 
         return {
-            onSelect
+            onSelect,
+            onOpen
         };
     }
 }
@@ -144,7 +162,8 @@ TreeNode.propTypes = {
         PropTypes.object,
         PropTypes.bool
     ]).isRequired,
-    onSelect: PropTypes.func
+    onSelect: PropTypes.func,
+    onOpen: PropTypes.func
 };
 
 export default TreeNode;

--- a/src/components/node.js
+++ b/src/components/node.js
@@ -14,11 +14,11 @@ class TreeNode extends React.Component {
     }
 
     onClick() {
-        const {node, onToggle} = this.props;
+        const {node, onSelect} = this.props;
         const {toggled} = node;
 
-        if (onToggle) {
-            onToggle(node, !toggled);
+        if (onSelect) {
+            onSelect(node, !toggled);
         }
     }
 
@@ -128,10 +128,10 @@ class TreeNode extends React.Component {
     }
 
     _eventBubbles() {
-        const {onToggle} = this.props;
+        const {onSelect} = this.props;
 
         return {
-            onToggle
+            onSelect
         };
     }
 }
@@ -144,7 +144,7 @@ TreeNode.propTypes = {
         PropTypes.object,
         PropTypes.bool
     ]).isRequired,
-    onToggle: PropTypes.func
+    onSelect: PropTypes.func
 };
 
 export default TreeNode;

--- a/src/components/treebeard.js
+++ b/src/components/treebeard.js
@@ -10,7 +10,7 @@ import defaultAnimations from '../themes/animations';
 
 class TreeBeard extends React.Component {
     render() {
-        const {animations, decorators, data: propsData, onSelect, style} = this.props;
+        const {animations, decorators, data: propsData, onSelect, onOpen, style} = this.props;
         let data = propsData;
 
         // Support Multiple Root Nodes. Its not formally a tree, but its a use-case.
@@ -26,6 +26,7 @@ class TreeBeard extends React.Component {
                               key={node.id || index}
                               node={node}
                               onSelect={onSelect}
+                              onOpen={onOpen}
                               style={style.tree.node}/>
                 )}
             </ul>
@@ -44,6 +45,7 @@ TreeBeard.propTypes = {
         PropTypes.bool
     ]),
     onSelect: PropTypes.func,
+    onOpen: PropTypes.func,
     decorators: PropTypes.object
 };
 

--- a/src/components/treebeard.js
+++ b/src/components/treebeard.js
@@ -10,7 +10,7 @@ import defaultAnimations from '../themes/animations';
 
 class TreeBeard extends React.Component {
     render() {
-        const {animations, decorators, data: propsData, onToggle, style} = this.props;
+        const {animations, decorators, data: propsData, onSelect, style} = this.props;
         let data = propsData;
 
         // Support Multiple Root Nodes. Its not formally a tree, but its a use-case.
@@ -25,7 +25,7 @@ class TreeBeard extends React.Component {
                               decorators={decorators}
                               key={node.id || index}
                               node={node}
-                              onToggle={onToggle}
+                              onSelect={onSelect}
                               style={style.tree.node}/>
                 )}
             </ul>
@@ -43,7 +43,7 @@ TreeBeard.propTypes = {
         PropTypes.object,
         PropTypes.bool
     ]),
-    onToggle: PropTypes.func,
+    onSelect: PropTypes.func,
     decorators: PropTypes.object
 };
 

--- a/test/src/components/decorator-tests.js
+++ b/test/src/components/decorator-tests.js
@@ -6,7 +6,6 @@ import React from 'react';
 import TestUtils from 'react-dom/test-utils';
 
 import {VelocityComponent} from 'velocity-react';
-import sinon from 'sinon';
 
 import defaultDecorators from '../../../src/components/decorators';
 
@@ -24,18 +23,6 @@ const defaults = {
 const Container = defaultDecorators.Container;
 
 describe('container decorator component', () => {
-    it('should render a clickable element with a click event handler', () => {
-        const onClick = sinon.spy();
-        const container = TestUtils.renderIntoDocument(
-            <Container {...defaults}
-                       onClick={onClick}/>
-        );
-        const clickable = container.clickableRef;
-        TestUtils.Simulate.click(clickable);
-
-        onClick.should.be.called.once;
-    });
-
     it('should render the toggle decorator not terminal', () => {
         class toggleType extends React.Component {
             render() {

--- a/test/src/components/header-tests.js
+++ b/test/src/components/header-tests.js
@@ -134,5 +134,4 @@ describe('header component', () => {
 
         global.should.not.exist(container.props.style.container[1]);
     });
-
 });

--- a/test/src/components/node-tests.js
+++ b/test/src/components/node-tests.js
@@ -29,29 +29,29 @@ describe('node component', () => {
 
     it('should invert the toggle state on click', (done) => {
         const node = {toggled: true};
-        const onToggle = (toggledNode, toggled) => {
+        const onSelect = (toggledNode, toggled) => {
             toggled.should.equal(!toggledNode.toggled);
             done();
         };
         const treeNode = TestUtils.renderIntoDocument(
             <TreeNode {...defaults}
                       node={node}
-                      onToggle={onToggle}/>
+                      onSelect={onSelect}/>
         );
         treeNode.onClick();
     });
 
-    it('should call the onToggle callback once if it is registered on click', () => {
-        const onToggle = sinon.spy();
+    it('should call the onSelect callback once if it is registered on click', () => {
+        const onSelect = sinon.spy();
         const treeNode = TestUtils.renderIntoDocument(
             <TreeNode
                 {...defaults}
-                onToggle={onToggle}
+                onSelect={onSelect}
             />
         );
         treeNode.onClick();
 
-        onToggle.should.be.called.once;
+        onSelect.should.be.called.once;
     });
 
     it('should not throw an exception if a callback is not registered on click', () => {

--- a/test/src/components/treebeard-tests.js
+++ b/test/src/components/treebeard-tests.js
@@ -34,12 +34,12 @@ describe('treebeard component', () => {
     it('should pass the top level tree node the associated props', () => {
         const treebeard = TestUtils.renderIntoDocument(
             <Treebeard data={defaults}
-                       onToggle={() => null}/>
+                       onSelect={() => null}/>
         );
         const node = TestUtils.findRenderedComponentWithType(treebeard, TreeNode);
 
         node.props.node.should.equal(treebeard.props.data);
-        node.props.onToggle.should.equal(treebeard.props.onToggle);
+        node.props.onSelect.should.equal(treebeard.props.onSelect);
     });
 
     it('should use the default theme if none specified', () => {


### PR DESCRIPTION
Decouple the node selection and expansion: node expansion will no longer select the node. Adds a new "onOpen" event that is triggered when a node is expanded.